### PR TITLE
Finished the work for adding the "following" checkboxes to the users page

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -217,30 +217,27 @@ a.novisited {color: #00e;}
    padding: 15px;
 }
 
+
 /*
- *  If the user has javascript turned on, show the 
- *  "following" checkboxes and turn off the "following" 
- *  text labels.
+ * By default only show the text label for the "Following" column on
+ * the users page.  If they have javascript turned on (detected
+ * via. the js-enabled class set by our page's javascript) then turn
+ * off the text label and turn on the checkbox.
  */
-#user-table input.following,  {
-    display: inline;
+#user-table input.following {
+    display: none;
 }
 
 #user-table span.following {
-    display: none;
-}
-
-/*
- *  If the user has javascript disabled, hide the 
- *  "following" checkboxes and fallback to showing
- *  the "following" text labels.
- */
-#user-table.javascript-disabled input.following {
-    display: none;
-}
-
-#user-table.javascript-disabled span.following {
     display: inline;
+}
+
+#user-table.js-enabled input.following {
+    display: inline;
+}
+
+#user-table.js-enabled span.following {
+    display: none;
 }
 
 

--- a/resources/public/script/foreclojure.js
+++ b/resources/public/script/foreclojure.js
@@ -39,9 +39,9 @@ $(document).ready(function() {
       return false;
   });
 
-  $("#user-table").removeClass('javascript-disabled');
+  $("#user-table").addClass("js-enabled");
 
-  $("form input.following").live("click", function(e) {
+  $("#user-table input.following").live("click", function(e) {
     e.preventDefault();
     var $checkbox = $(this)
     var $form = $checkbox.parents("form")

--- a/src/foreclojure/users.clj
+++ b/src/foreclojure/users.clj
@@ -81,10 +81,9 @@
 
 (defn following-checkbox [current-user-id following user-id user]
   (when (and current-user-id (not= current-user-id user-id))
-    (let [following? (following user-id)]
+    (let [following? (contains? following user-id)]
       (form-to [:post (follow-url user (not following?))]
-               [:input.following {:type "checkbox" :name "following"
-                                  :checked following? :value following?}]
+               [:input.following {:type "checkbox" :checked following?}]
                [:span.following (when following? "yes")]))))
 
 (defn generate-user-list [user-set]
@@ -94,7 +93,7 @@
             [_id (set following)]))]
     (list
      [:br]
-     [:table#user-table.my-table.javascript-disabled
+     [:table#user-table.my-table
       [:thead
        [:tr
         [:th {:style "width: 40px;"} "Rank"]


### PR DESCRIPTION
Finished the work for adding the "following" checkboxes to the users page. (Issue 117)
- In the case where the user has javascript disabled, we fall back to
  just showing a "yes" in the following column instead of the checkbox.
- Optimized checking to see if a user was being followed by making the
  following vector into a set.
- Hooked up the "Follow" buttons on the user profile page to use AJAX
  instead of another page load (which also fixes the back button issue
  with this).
