### PR TITLE
Fixing a bug when requesting a non-existing user's profile page

### DIFF
--- a/src/foreclojure/users.clj
+++ b/src/foreclojure/users.clj
@@ -3,7 +3,7 @@
             [clojure.string           :as string]
             [sandbar.stateful-session :as session]
             [cheshire.core            :as json])
-  (:use     [foreclojure.utils        :only [from-mongo row-class rank-class get-user if-user with-user]]
+  (:use     [foreclojure.utils        :only [from-mongo row-class rank-class get-user if-user with-user flash-error ]]
             [foreclojure.template     :only [def-page content-page]]
             [foreclojure.ring-utils   :only [*http-scheme* static-url]]
             [foreclojure.config       :only [config repo-url]]
@@ -164,7 +164,7 @@
        :heading-note [:span#all-users-link]
        :sub-heading (list (format-user-ranking user-ranking)
                           [:span.contributor "*"] "&nbsp;"
-                          (link-to repo-url "4clojure contributor"))
+                          (link-to repo-url "4clojure contributor") [:br])
        :main (generate-user-list top-100 "user-table")})}))
 
 ;; TODO: this is snagged from problems.clj but can't be imported due to cyclic dependency, must refactor this out.
@@ -294,7 +294,10 @@
 (defroutes users-routes
   (GET  "/users" [] (top-users-page))
   (GET  "/users/all" [] (all-users-page))
-  (GET  "/user/:username" [username] (user-profile username))
+  (GET  "/user/:username" [username] 
+    (if (nil? (get-user username)) 
+      {:status 404 :headers {"Content-Type" "text/plain"} :body "Error: This user does not exist, nice try though."}
+      (user-profile username)))
   (POST "/user/follow/:username" [username] (static-follow-user username true))
   (POST "/user/unfollow/:username" [username] (static-follow-user username false))
   (POST "/rest/user/follow/:username" [username] (rest-follow-user username true))


### PR DESCRIPTION
Fixing a bug where a user would try to lookup a non-existing user's profile and in return would get a empty profile.

Now the server returns a 404 with an error message.

This is related to fixing this issue:
https://github.com/4clojure/4clojure/issues/144
