### PR TITLE
Get rid of whitespace, meta information that push the problem way below

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -7,6 +7,15 @@ body {
    text-align: center;
 }
 
+div#right-title {
+  float: right;
+}
+div#title-rule {
+    clear: right;
+    margin-bottom: 5px;
+    border-bottom: 1px solid;
+}
+
 img {border:none}
 
 div.progress-bar-bg {
@@ -78,7 +87,7 @@ div.progress-bar {
 
 #top {
    width: 85%;
-   padding: 15px 0px 15px 0px;
+   padding: 0px 0px 15px 0px;
    margin: 0 auto;
 }
 div#top a {
@@ -188,7 +197,7 @@ img.gravatar{
    height: 84px;
    margin-left: -7px;
    float:left;
-   padding:15px 0px 15px 0px;
+   padding:0px 0px 15px 0px;
    border: 0;
 }
 

--- a/src/foreclojure/problems.clj
+++ b/src/foreclojure/problems.clj
@@ -270,18 +270,19 @@ Return a map, {:message, :error, :url, :num-tests-passed}."
     {:title (str _id ". " title)
      :content
      [:div
+      [:div {:id "right-title"}
+       [:table#tags
+        [:tr [:th "Difficulty:"] [:td (or difficulty "N/A")]]
+        [:tr [:th "Topics:"]     [:td (s/join " " tags)]]]
+       ]
       [:div#prob-title title]
       (if-user [{:keys [solved]}]
         (if (some #{(Integer. id)} solved)
-          (link-to (str "/problem/solutions/" id)
-                   [:button#solutions-link {:type "submit"} "Solutions"])
-          [:div {:style "clear: right; margin-bottom: 15px;"} "&nbsp;"])
-        [:div {:style "clear: right; margin-bottom: 15px;"} "&nbsp;"])
-      [:hr]
-      [:table#tags
-       [:tr [:td "Difficulty:"] [:td (or difficulty "N/A")]]
-       [:tr [:td "Topics:"]     [:td (s/join " " tags)]]]
-      [:br]
+          [:div
+           (link-to (str "/problem/solutions/" id)
+                    [:button#solutions-link {:type "submit"} "Solutions"])
+           "Or go to "[:a {:href "#instruct"} "your solution"]]))
+      [:div {:id "title-rule"}]
       (when-not approved
         [:div#submitter "Submitted by: "
          (users/mailto user)])


### PR DESCRIPTION
Also add a "go to your solution" anchor link.

(Later I intend to compress the menu to appear to the right of, instead of below, the logo).
