### PR TITLE
Add delay to user filtering.

### DIFF
--- a/resources/public/script/foreclojure.js
+++ b/resources/public/script/foreclojure.js
@@ -172,7 +172,7 @@ function configureDataTables(){
         "bProcessing": true,
         "bServerSide": true,
         "sAjaxSource": "/datatable/users"
-    } );
+    } ).fnSetFilteringDelay(300);
 }
 
 function setIconColor(element, color, timeOut, stopAnimation) {

--- a/resources/public/vendor/script/jquery.dataTables.fnSetFilteringDelay.js
+++ b/resources/public/vendor/script/jquery.dataTables.fnSetFilteringDelay.js
@@ -1,0 +1,34 @@
+// Source http://datatables.net/plug-ins/api
+
+jQuery.fn.dataTableExt.oApi.fnSetFilteringDelay = function ( oSettings, iDelay ) {
+    var _that = this;
+
+    if ( iDelay === undefined ) {
+        iDelay = 250;
+    }
+
+    this.each( function ( i ) {
+        $.fn.dataTableExt.iApiIndex = i;
+        var
+            $this = this,
+            oTimerId = null,
+            sPreviousSearch = null,
+            anControl = $( 'input', _that.fnSettings().aanFeatures.f );
+
+            anControl.unbind( 'keyup' ).bind( 'keyup', function() {
+            var $$this = $this;
+
+            if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
+                window.clearTimeout(oTimerId);
+                sPreviousSearch = anControl.val();
+                oTimerId = window.setTimeout(function() {
+                    $.fn.dataTableExt.iApiIndex = i;
+                    _that.fnFilter( anControl.val() );
+                }, iDelay);
+            }
+        });
+
+        return this;
+    } );
+    return this;
+};

--- a/src/foreclojure/template.clj
+++ b/src/foreclojure/template.clj
@@ -22,7 +22,7 @@
        [:style {:type "text/css"}
         ".syntaxhighlighter { overflow-y: hidden !important; }"]
        (css "css/style.css" "css/demo_table.css" "css/shCore.css" "css/shThemeDefault.css")
-       (js "vendor/script/jquery-1.5.2.min.js" "vendor/script/jquery.dataTables.min.js" "vendor/script/jquery.flipCounter.1.1.pack.js" "vendor/script/jquery.easing.1.3.js")
+       (js "vendor/script/jquery-1.5.2.min.js" "vendor/script/jquery.dataTables.min.js" "vendor/script/jquery.flipCounter.1.1.pack.js" "vendor/script/jquery.easing.1.3.js" "vendor/script/jquery.dataTables.fnSetFilteringDelay.js")
        (js "script/codebox.js" "script/foreclojure.js")
        (js "vendor/script/xregexp.js" "vendor/script/shCore.js" "vendor/script/shBrushClojure.js")
        (js "vendor/script/ace/ace.js" "vendor/script/ace/mode-clojure.js")


### PR DESCRIPTION
Ajax filter requests are sent on every keyup now. So if you want to search for "qwerty" 6 requests will be sent. It creates considerable load for server and all requests are timeout. Also site becomes unresponsive for sometime (504 Gateway Time-Out).  
I added delay for filtering: script waits 300ms after user finished input and then sends filter request.
