### PR TITLE
Show solutions from top users on problem solutions page

### DIFF
--- a/src/foreclojure/problems.clj
+++ b/src/foreclojure/problems.clj
@@ -340,7 +340,9 @@ Return a map, {:message, :error, :url, :num-tests-passed}."
 
 (defn solution-block [username code]
   [:div.follower-solution
-   [:div.solution-username (str username "'s solution:")]
+   [:div.solution-username
+    (link-to (str "/user/" username) username)
+    "'s solution:"]
    [:pre.solution-code
     (escape-html code)]])
 


### PR DESCRIPTION
I've introduced many people to Clojure by way of 4Clojure, and several have been confused on why they need to follow users to see other solutions. This patch adds code to display a few of the solutions from the top users for a given problem. (Somewhat related to #152.)

![Screen Shot 2013-03-20 at 10 39 48 AM](https://f.cloud.github.com/assets/6968/281993/3445ec76-9185-11e2-9dc6-adcbbf74482e.png)

Alternatively (/ additionally), we could show solutions from random users. Please let me know your thoughts!

Thanks,
Hans Engel
