### PR TITLE
Username made as hyperlink to users profile page

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -164,6 +164,10 @@ img.gravatar{
    border-right: 2px solid white;
 }
 
+#username a {
+   font-size: 12px;
+}
+
 .contributor {
    color: #458B00;
    font-weight: bold;

--- a/src/foreclojure/template.clj
+++ b/src/foreclojure/template.clj
@@ -50,7 +50,7 @@
          [:div#user-info
           (if user
             [:div
-             [:span#username (str "Logged in as " user)]
+             [:span#username "Logged in as " [:a {:href (str "/user/" user)} user]]
              [:a#logout {:href "/logout"} "Logout"]]
             [:div
              [:a#login {:href (login-url)} "Login"]


### PR DESCRIPTION
There is a user profile page with user's progress (/user/name). I didn't find a link to this page so I added it from the username in the top menu.
![logged_in_as](https://f.cloud.github.com/assets/1009751/517546/3539970c-bee1-11e2-9f13-f5d6f8de3dbb.png)
