### PR TITLE
Allow code boxes to scroll when there's no room

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -637,12 +637,10 @@ a.graph-class :hover {color: #445599;}
 
 .CodeMirror .CodeMirror-scroll {
     height: auto;
-    overflow: visible;
 }
 
 .CodeMirror.codebox .CodeMirror-scroll {
     height: 300px;
-    overflow: auto;
 }
 
 .codebox {


### PR DESCRIPTION
Otherwise the code just gets hidden off-screen. E.g. on the solutions page:

![Screen shot showing hidden overflow](https://cloud.githubusercontent.com/assets/153175/2837183/c22c7a94-d010-11e3-8887-3e36813674fa.png)
