### PR TITLE
Auto-Focus Editor and Run Code on Shift-Enter

### DIFF
--- a/resources/public/script/codebox.js
+++ b/resources/public/script/codebox.js
@@ -21,6 +21,7 @@ var CodeBox = {
 
     if(!this.disableJavascript && this.submitButtons.length > 0 || isSettingsPage) {
       this.setupEditor();
+      this.setupKeypressEvents();
     }
 
     $("#run-button").live("click", $.proxy(this.run, this));
@@ -139,4 +140,14 @@ var CodeBox = {
   stopAnimation: function() {
     this.images.stop(true).removeClass("animated").css({ opacity: 1.0, });
   },
+
+  setupKeypressEvents: function() {
+    function submitOnShiftEnter (event) {
+      if (event.keyCode === 13 && event.shiftKey === true) {
+        this.run(event);
+      }
+    };
+
+    this.wrapperElement.keypress($.proxy(submitOnShiftEnter, this));
+  }
 }

--- a/resources/public/script/codebox.js
+++ b/resources/public/script/codebox.js
@@ -4,6 +4,7 @@ var CodeBox = {
   element:            null,
   submitButtons:      null,
   editor:             null,
+  wrapperElement:     null,
   allEditors:         [],
   high:               false,
   animationTime:      800,
@@ -31,7 +32,9 @@ var CodeBox = {
                                          {mode: 'clojure',
                                           lineNumbers: true,
                                           theme: this.theme});
-    $(this.editor.getWrapperElement()).addClass('codebox');
+
+    this.wrapperElement = $(this.editor.getWrapperElement());
+    this.wrapperElement.addClass('codebox');
     $('#theme').live('change', function() {
       var theme = $(this).val();
       CodeBox.editor.setOption('theme', theme);

--- a/resources/public/script/codebox.js
+++ b/resources/public/script/codebox.js
@@ -31,6 +31,7 @@ var CodeBox = {
   setupEditor: function() {
     this.editor = CodeMirror.fromTextArea(this.element[0],
                                          {mode: 'clojure',
+                                          autofocus: true,
                                           lineNumbers: true,
                                           theme: this.theme});
 


### PR DESCRIPTION
This PR aims to allow users to work through the early 4clojure faster by:
- Running the problem when Shift-Enter is pressed.
- Auto-focussing the editor when the problem page is loaded.

Keyboard short-cuts are mentioned in issues #151 and #240. This change does not cover all the short-cuts mentioned in #151 and uses a different key combination than issue #240.

Let me know if a different key combination is required or if there is a straight-forward way to implement the other keyboard shortcuts mentioned in #151. These changes seemed like a quick win to me.
