### PR TITLE
Fix problem #47 for contains? behaviour in clojure 1.5

### DIFF
--- a/src/foreclojure/data_set.clj
+++ b/src/foreclojure/data_set.clj
@@ -530,7 +530,7 @@
             :tests ["(contains? #{4 5 6} __)"
                     "(contains? [1 1 1 1 1] __)"
                     "(contains? {4 :a 2 :b} __)"
-                    "(not (contains? '(1 2 4) __))"]})
+                    "(not (contains? [1 2 4] __))"]})
 
        (insert! :problems
            {:_id 48


### PR DESCRIPTION
In clojure 1.5.1:

```clojure
user=> (not (contains? '(1 2 4) 4))

IllegalArgumentException contains? not supported on type: clojure.lang.PersistentList  clojure.lang.RT.contains (RT.java:724)
```