### PR TITLE
Ignore comments in code golf score

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ vaguely like this:
 * [Martin Sander](https://github.com/marvinthepa) (0x89)
 * [Alex McNamara](https://github.com/amcnamara) (amcnamara)
 * [Ara Jeknavorian](https://github.com/arajek) (arajek)
-
+* [Thomas Lamb](https://github.com/tclamb) (tclamb)
 
 Problem sources:
 

--- a/resources/config.clj
+++ b/resources/config.clj
@@ -16,5 +16,5 @@
  :golfing-active true
  :heartbeat nil ; set to, eg, [1 :hour] for periodic heap information on stdout
  ;; this list is just for bootstrapping - the real DB is authoritative
- :contributors ["amalloy" "dbyrne" "raynes" "cmeier" "devn" "0x89"
-                "citizen428" "daviddavis" "clinteger" "amcnamara"]}
+ :contributors ["amalloy" "dbyrne" "raynes" "cmeier" "devn" "amcnamara"
+                "citizen428" "daviddavis" "clinteger" "tclamb" "0x89"]}

--- a/test/foreclojure/test/problems.clj
+++ b/test/foreclojure/test/problems.clj
@@ -1,0 +1,50 @@
+(ns foreclojure.test.problems
+  (:use [foreclojure.problems])
+  (:use [clojure.test])
+  (:use [midje.sweet]))
+
+(let [code "(I AM SOME COOL CODE 111)"
+      commented-code (str "(I AM SOME ;REALLY\n"
+                          "   COOL,   ;COOL\n"
+                          "   CODE 111)")
+      internal-semicolon "(do \"s;s\" \\; (fn [coll] ((fn dist [prev coll] (lazy-seq (when-let [[x & xs] (seq coll)] (let [more (dist (conj prev x) xs)] (if (contains? prev x) more (cons x more)))))) #{} coll))) ;plus a comment :)"
+      anonymous-function "reduce #(update-in % [%2] (fnil inc 0)) {}"]
+  (deftest test-code-length
+    (fact "code-length counts characters in code"
+      (code-length code) => 20)
+    (fact "code-length can handle comments"
+      (code-length commented-code) => 20)
+    (fact "code-length can handle escaped semicolons"
+      (code-length internal-semicolon) => 150)
+    (fact "code-length can handle anonymous functions"
+      (code-length anonymous-function) => 35)
+    (fact "code-length can handle empty data structures"
+      (code-length "[{} #{} [] () \"\"]") => 13)
+    (fact "code-length can handle metadata"
+      (code-length "^String ^dynamic ^{:key :value} ^:test") => 34)
+    (fact "code-length can handle unquotes"
+      (code-length "`(1 2 ~(list 3 4) ~@(list 3 4))") => 24)
+    (fact "code-length can handle regexes"
+      (code-length ".split #\"\\n\"") => 11)
+    (fact "code-length can handle quotes"
+      (code-length "'() #'var") => 8)
+    (fact "code-length can handle derefs"
+      (code-length "@form") => 5)
+    (fact "code-length doesn't simplify literals"
+      (code-length "1.00 10/5") => 8)
+    (fact "code-length can handle nils"
+      (code-length "nil (nil)") => 8)
+    (fact "code-length can handle double-quote shenanigans"
+      (code-length "\";\\\";\\\";\"\";\\\";\";\";\\\";\"") => 15
+      (code-length "\";\\\";\\\";\", \";\\\";\", ;\";\\\";\"") => 15
+      (code-length "\"\\\";\";test\"comment;\"\\\"") => 5)
+    (fact "code-length can handle multi-line strings"
+      (code-length "\";
+;\" ;newline at cost of 1") => 5
+      (code-length "\";\\n;\" ;newline at cost of 2") => 6)
+    (fact "code-length doesn't double count dos line-endings"
+      (code-length "\";\r\n;\"") => (count "\";
+;\"")
+      (code-length "\";\r\n;\"") => 5)
+    (fact "code-length counts #_" ;probably not worth fixing
+      (code-length "#_ hello") => 7)))


### PR DESCRIPTION
Fix for code golf is in the first commit. In the rest of the commits:
- Pulled `:difficulty` out of `:tags` in `foreclojure.data-set` (to match changes to `problems` table)
- Removed duplicate definition of problem 56 in `foreclojure.data-set`
- Fixed syntax error in `foreclojure.test.users`
- Updated dependencies to latest versions
  - Updated `foreclojure.test.users` to pass by mocking out (noir.session/get)

All tests are now passing. I ran `lein ring server` and verified the various fixes worked. As for verifying dependencies played nice, I created a couple of users, followed each other, solved some problems with both, and didn't notice any errors in the site's core functionality.
