### PR TITLE
typo fixed in RSS feed

### DIFF
--- a/src/foreclojure/feeds.clj
+++ b/src/foreclojure/feeds.clj
@@ -20,7 +20,7 @@
                             :type "application/rss+xml"})
        (element :title {} feed-title)
        (element :link {} feed-link)
-       (element :descrption {} feed-description)
+       (element :description {} feed-description)
        items))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
`descrption` -> `description`
