### PR TITLE
Trim leading and trailing spaces from username at login

### DIFF
--- a/src/foreclojure/login.clj
+++ b/src/foreclojure/login.clj
@@ -40,7 +40,7 @@
       {:main login-box})}))
 
 (defn do-login [user pwd]
-  (let [user (.toLowerCase user)
+  (let [user (-> user .toLowerCase .trim)
         {db-pwd :pwd} (from-mongo (fetch-one :users :where {:user user}))
         location (session/get :login-to)]
     (if (and db-pwd (.checkPassword (StrongPasswordEncryptor.) pwd db-pwd))


### PR DESCRIPTION
I ran into a problem where Chrome on Android was including a space after my username when it tried to autofill it (eg. "testuser " instead of "testuser") which made the login fail repeatedly despite looking like my correct username and password.

Since usernames have to match `#"[A-Za-z0-9_]+"` trimming it should be fine.
