### PR TITLE
remove broken REPL link

### DIFF
--- a/src/foreclojure/template.clj
+++ b/src/foreclojure/template.clj
@@ -42,7 +42,6 @@
                 ["/problems" "Problem List"]
                 ["/users" "Top Users"]
                 ["/directions" "Help"]
-                ["http://try-clojure.org" "REPL" true]
                 ["http://clojuredocs.org" "Docs" true]]]
            [:a.menu (assoc (when tabbed {:target "_blank"})
                       :href link)
@@ -51,7 +50,7 @@
           (if user
             [:div
              [:span#username (str "Logged in as")
-             [:a (make-user-url user) user]]
+              [:a (make-user-url user) user]]
              [:a#logout {:href "/logout"} "Logout"]]
             [:div
              [:a#login {:href (login-url)} "Login"]
@@ -84,8 +83,8 @@
             var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
             ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-          })();"
-         )]]])))
+          })();")]]])))
+
 
 ;; Content templates
 (defn content-page [{:keys [heading heading-note sub-heading main]}]


### PR DESCRIPTION
[http://try-clojure.org](http://try-clojure.org) is no longer hosted, we could find a replacement or just remove it for now.
I tried [https://repl.it/site/languages/clojure](https://repl.it/site/languages/clojure), but it is incredibly slow.